### PR TITLE
POC: dynamic asserts

### DIFF
--- a/tests/integration/dynamic-asserts-poc-test.js
+++ b/tests/integration/dynamic-asserts-poc-test.js
@@ -1,0 +1,46 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+import { attribute, create, hasClass } from 'ember-cli-page-object';
+import hbs from 'htmlbars-inline-precompile';
+
+const page = create({
+  password: {
+    scope: '[name="password"]',
+    isHighlighted: hasClass('highlighted'),
+  },
+  link: {
+    scope: 'a',
+    href: attribute('href'),
+    isActive: hasClass('active')
+  }
+});
+
+module('dynamic asserts poc', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function() {
+    await render(hbs`
+      <a href="http://google.com"> Test </a>
+
+      <input name="password" class="highlighted">
+    `);
+  });
+
+  test('1', function(assert) {
+    assert.po(page.link).text.includes('est');
+  });
+
+  test('2', function(assert) {
+    assert.po(page.link).isActive(false);
+  });
+
+  test('3', function(assert) {
+    assert.po(page.link).text.is('Test');
+  });
+
+  test('4', function(assert) {
+    assert.po(page.link).href.is('http://google.com');
+  });
+});


### PR DESCRIPTION
a poc on #1 . Not supposed to be merged, just gathering feedback. 

What do you think?

Some releted questions:
 - `has(` VS `is(`. Do we need to choose one or use both? Right now `is(` is an alias to `has(`. I avoided using `has`, cause it may be confusing when used alongside `includes(`.
 - do we still need the other static [asserts](https://github.com/yratanov/ember-page-object-asserts/blob/54ae7b69940fc47724a7c5168e2923a288ed8abc/addon/page-object-assert.ts#L23-L63)? I think it can be difficult to maintain, and dynamic assertions should cover most of use cases? 