### PR TITLE
stop calling attributes on page object to check if it's a function

### DIFF
--- a/addon/page-object-assert.ts
+++ b/addon/page-object-assert.ts
@@ -30,8 +30,8 @@ export class PageObjectAssert {
   }
 
   private buildAssertionsForProps() {
-    for (let [prop, value] of Object.entries(this.po)) {
-      if (this.po.hasOwnProperty(prop) && typeof value !== 'function') {
+    for (let prop in this.po) {
+      if (this.po.hasOwnProperty(prop)) {
         this.buildAssertionFor(prop);
       }
     }
@@ -42,7 +42,7 @@ export class PageObjectAssert {
     let po = this.po;
 
     let assertFunc = function(func: Function) {
-      return function (value: any, message?: string) {
+      return function(value: any, message?: string) {
         pushResult(po, assert, func(po, prop, value, message));
       };
     };

--- a/addon/page-object-assert.ts
+++ b/addon/page-object-assert.ts
@@ -31,9 +31,7 @@ export class PageObjectAssert {
 
   private buildAssertionsForProps() {
     for (let prop in this.po) {
-      if (this.po.hasOwnProperty(prop)) {
-        this.buildAssertionFor(prop);
-      }
+      this.buildAssertionFor(prop);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -830,9 +830,9 @@
       }
     },
     "@babel/register": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.8.3.tgz",
-      "integrity": "sha512-t7UqebaWwo9nXWClIPLPloa5pN33A2leVs8Hf0e9g9YwUP8/H9NeR7DJU+4CXo23QtjChQv5a3DjEtT83ih1rg==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.8.6.tgz",
+      "integrity": "sha512-7IDO93fuRsbyml7bAafBQb3RcBGlCpU4hh5wADA2LJEEcYk92WkwFZ0pHyIi2fb5Auoz1714abETdZKCOxN0CQ==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
@@ -5816,7 +5816,7 @@
     },
     "ember-cli-code-coverage": {
       "version": "github:kategengler/ember-cli-code-coverage#d6e2262923e7caeeb383fb6ccdf7b46e227f5715",
-      "from": "github:kategengler/ember-cli-code-coverage#d6e2262923e7caeeb383fb6ccdf7b46e227f5715",
+      "from": "github:kategengler/ember-cli-code-coverage",
       "dev": true,
       "requires": {
         "@babel/register": "^7.6.0",

--- a/tests/integration/bypassing-properties-test.js
+++ b/tests/integration/bypassing-properties-test.js
@@ -58,20 +58,4 @@ module('bypassing properties', function(hooks) {
   test('checks custom property', async function(assert) {
     assert.po(page.password).customField.is('value');
   });
-
-  test('raises error if property is a custom function', async function(assert) {
-    try {
-      assert.po(page.password).clack();
-    } catch (e) {
-      assert.equal(e.message, 'assert.po(...).clack is not a function')
-    }
-  });
-
-  test('raises error if property is a default function', async function(assert) {
-    try {
-      assert.po(page.password).click();
-    } catch (e) {
-      assert.equal(e.message, 'assert.po(...).click is not a function')
-    }
-  });
 });

--- a/tests/integration/is-present-test.js
+++ b/tests/integration/is-present-test.js
@@ -2,12 +2,13 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 
-import { create } from 'ember-cli-page-object';
+import { create, attribute } from 'ember-cli-page-object';
 import hbs from 'htmlbars-inline-precompile';
 
 const page = create({
   element: {
     scope: '.element',
+    notExisting: attribute('href', 'a')
   }
 });
 


### PR DESCRIPTION
The way we check if page object field is a getter/property is flawed by the fact that we actually call it. So if it raises an error, for example if getter can't find an element, then our test will be broken. To avoid it we won't pretend being smart and bypass all object fields to the assert. It's a tradeoff, but since we don't have any other valid ways to check what's in the field without executing it, we won't make any assumptions.